### PR TITLE
Add Scala 3 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.6, 2.12.14]
+        scala: [2.13.6, 2.12.14, 3.0.1]
         java: [adopt@1.8, adopt@1.11]
     runs-on: ${{ matrix.os }}
     steps:
@@ -122,6 +122,16 @@ jobs:
           name: target-${{ matrix.os }}-2.12.14-${{ matrix.java }}
 
       - name: Inflate target directories (2.12.14)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.0.1)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-3.0.1-${{ matrix.java }}
+
+      - name: Inflate target directories (3.0.1)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/ci-release.sbt
+++ b/ci-release.sbt
@@ -1,5 +1,9 @@
 ThisBuild / scalaVersion := Dependencies.Versions.scala213
-ThisBuild / crossScalaVersions := Seq(Dependencies.Versions.scala213, Dependencies.Versions.scala212)
+ThisBuild / crossScalaVersions := Seq(
+  Dependencies.Versions.scala213,
+  Dependencies.Versions.scala212,
+  Dependencies.Versions.scala301
+)
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
 ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@1.11")
 

--- a/ci-release.sbt
+++ b/ci-release.sbt
@@ -2,7 +2,7 @@ ThisBuild / scalaVersion := Dependencies.Versions.scala213
 ThisBuild / crossScalaVersions := Seq(
   Dependencies.Versions.scala213,
   Dependencies.Versions.scala212,
-  Dependencies.Versions.scala301
+  Dependencies.Versions.scala3
 )
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")
 ThisBuild / githubWorkflowJavaVersions := Seq("adopt@1.8", "adopt@1.11")

--- a/modules/jaeger-thrift-exporter/src/main/scala/io/janstenpickle/trace4cats/jaeger/JaegerSpanExporter.scala
+++ b/modules/jaeger-thrift-exporter/src/main/scala/io/janstenpickle/trace4cats/jaeger/JaegerSpanExporter.scala
@@ -2,7 +2,6 @@ package io.janstenpickle.trace4cats.jaeger
 
 import java.nio.ByteBuffer
 import java.util.concurrent.TimeUnit
-import alleycats.std.iterable._
 import cats.Foldable
 import cats.data.NonEmptyList
 import cats.effect.kernel.{Async, Resource, Sync}
@@ -113,7 +112,7 @@ object JaegerSpanExporter {
 
             process match {
               case None =>
-                val grouped: Iterable[(Process, java.util.List[Span])] =
+                val grouped: List[(Process, java.util.List[Span])] =
                   batch.spans
                     .foldLeft(Map.empty[String, ListBuffer[Span]]) { case (acc, span) =>
                       acc.updated(
@@ -124,6 +123,7 @@ object JaegerSpanExporter {
                     }
                     .view
                     .map { case (service, spans) => (new Process(service), spans.asJava) }
+                    .toList
                 grouped.traverse_((send _).tupled)
 
               case Some(tp) =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   object Versions {
     val scala212 = "2.12.14"
     val scala213 = "2.13.6"
-    val scala301 = "3.0.1"
+    val scala3 = "3.0.1"
 
     val trace4cats = "0.12.0-RC2+17-d73c7ff3"
     val trace4catsJaegerIntegrationTest = "0.12.0-RC2+7-e4062471"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,8 +6,8 @@ object Dependencies {
     val scala213 = "2.13.6"
     val scala301 = "3.0.1"
 
-    val trace4cats = "0.12.0-RC2"
-    val trace4catsJaegerIntegrationTest = "0.12.0-RC2"
+    val trace4cats = "0.12.0-RC2+17-d73c7ff3"
+    val trace4catsJaegerIntegrationTest = "0.12.0-RC2+7-e4062471"
 
     val collectionCompat = "2.5.0"
     val jaeger = "1.6.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,6 +4,7 @@ object Dependencies {
   object Versions {
     val scala212 = "2.12.14"
     val scala213 = "2.13.6"
+    val scala301 = "3.0.1"
 
     val trace4cats = "0.12.0-RC2"
     val trace4catsJaegerIntegrationTest = "0.12.0-RC2"


### PR DESCRIPTION
alleycats is no longer a transitive dependency, hence the single usage of it is rewriten as well. Requires a Scala 3-enabled version of trace4cats components it depends on, see https://github.com/trace4cats/trace4cats/pull/587